### PR TITLE
add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+import { Readable, Transform } from 'stream'
+
+/**
+ * Beautifies a LaTeX document.
+ *
+ * @param src
+ * The LaTeX document.
+ */
+declare function beautify(src: Readable | string) : Transform
+
+export default beautify

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "A beautifier for LaTeX documents.",
   "main": "index.js",
+  "types": "./index.d.ts",
   "repository": "saadq/pretty-latex",
   "author": {
     "name": "Saad Quadri",


### PR DESCRIPTION
I wanted to use pretty-latex in [resumake.io](https://github.com/saadq/resumake.io), but it was complaining about missing types.

I am not super familiar with how `.d.ts` files work, so I used https://github.com/saadq/node-latex/pull/18 as a reference.